### PR TITLE
Deprecation fixes

### DIFF
--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -434,7 +434,7 @@ def complete_structure_mask(
             plot_it(binarized_image_array)
         # Define kernel and apply
         kernel = np.ones((blur_factor, blur_factor))
-        blurred_image_array = binary_erosion(binarized_image_array, selem=kernel)
+        blurred_image_array = binary_erosion(binarized_image_array, footprint=kernel)
         if debug:
             plot_it(blurred_image_array)
         # Slice mask array along third dimension into single masks

--- a/decimer_segmentation/mrcnn/model.py
+++ b/decimer_segmentation/mrcnn/model.py
@@ -1416,7 +1416,7 @@ def load_image_gt(dataset, config, image_id, augmentation=None):
         # Make augmenters deterministic to apply similarly to images and masks
         det = augmentation.to_deterministic()
         image = det.augment_image(image)
-        # Change mask to np.uint8 because imgaug doesn't support np.bool
+        # Change mask to np.uint8 because imgaug doesn't support bool
         mask = det.augment_image(
             mask.astype(np.uint8), hooks=imgaug.HooksImages(activator=hook)
         )
@@ -1424,7 +1424,7 @@ def load_image_gt(dataset, config, image_id, augmentation=None):
         assert image.shape == image_shape, "Augmentation shouldn't change image size"
         assert mask.shape == mask_shape, "Augmentation shouldn't change mask size"
         # Change mask back to bool
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     # Note that some boxes might be all zeros if the corresponding mask got cropped out.
     # and here is to filter them out
@@ -1480,7 +1480,7 @@ def build_detection_targets(rpn_rois, gt_class_ids, gt_boxes, gt_masks, config):
         gt_class_ids.dtype
     )
     assert gt_boxes.dtype == np.int32, "Expected int but got {}".format(gt_boxes.dtype)
-    assert gt_masks.dtype == np.bool_, "Expected bool but got {}".format(gt_masks.dtype)
+    assert gt_masks.dtype == bool_, "Expected bool but got {}".format(gt_masks.dtype)
 
     # It's common to add GT Boxes to ROIs but we don't do that here because
     # according to XinLei Chen's paper, it doesn't help.

--- a/decimer_segmentation/mrcnn/utils.py
+++ b/decimer_segmentation/mrcnn/utils.py
@@ -523,7 +523,7 @@ def minimize_mask(bbox, mask, mini_shape):
             raise Exception("Invalid bounding box with area of zero")
         # Resize with bilinear interpolation
         m = resize(m, mini_shape)
-        mini_mask[:, :, i] = np.around(m).astype(np.bool)
+        mini_mask[:, :, i] = np.around(m).astype(bool)
     return mini_mask
 
 
@@ -540,7 +540,7 @@ def expand_mask(bbox, mini_mask, image_shape):
         w = x2 - x1
         # Resize with bilinear interpolation
         m = resize(m, (h, w))
-        mask[y1:y2, x1:x2, i] = np.around(m).astype(np.bool)
+        mask[y1:y2, x1:x2, i] = np.around(m).astype(bool)
     return mask
 
 
@@ -559,10 +559,10 @@ def unmold_mask(mask, bbox, image_shape):
     threshold = 0.5
     y1, x1, y2, x2 = bbox
     mask = resize(mask, (y2 - y1, x2 - x1))
-    mask = np.where(mask >= threshold, 1, 0).astype(np.bool)
+    mask = np.where(mask >= threshold, 1, 0).astype(bool)
 
     # Put the mask in the right location.
-    full_mask = np.zeros(image_shape[:2], dtype=np.bool)
+    full_mask = np.zeros(image_shape[:2], dtype=bool)
     full_mask[y1:y2, x1:x2] = mask
     return full_mask
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     license="MIT",
     install_requires=[
-        "tensorflow>=2.10.0",
+        "tensorflow==2.10.0",
         "scikit-image",
         "pillow",
         "opencv-python",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setuptools.setup(
     license="MIT",
     install_requires=[
         "tensorflow==2.10.0",
-        "scikit-image",
+        "numpy>=1.2.0",
+        "scikit-image>=0.2.0",
         "pillow",
         "opencv-python",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     license="MIT",
     install_requires=[
-        "tensorflow==2.10.0",
+        "tensorflow>=2.10.0",
         "scikit-image",
         "pillow",
         "opencv-python",


### PR DESCRIPTION
New installs fail on Windows and Linux due to loose requirements/deprecated features #65 

- np.bool was depreacted in numpy 1.20: https://numpy.org/doc/stable/release/1.20.0-notes.html
  - update all instances of `np.bool` to `bool` as recommended in release notes
  - specify numpy version >=1.20
- scitkit-image 0.20.0 deprecated the `selem` kwarg: https://scikit-image.org/docs/stable/release_notes.html
  - replace with `footprint`  as recommended in release notes
  - specify scikit-image >= 0.20.0

Unit tests pass and example notebook runs on Windows + Linux