### PR TITLE
Horizontal vertical line exclusion

### DIFF
--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -458,7 +458,7 @@ def expansion_coordination(mask_array: np.array,
             image_array=image_array, bounding_box=polygon[0]
         )
         mask_array = expand_masks(
-            image_array, seed_pixels, mask_array, contour_expansion=True
+            image_array, seed_pixels, mask_array, exclusion_mask, contour_expansion=True
         )
     return mask_array
 

--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -400,7 +400,7 @@ def expand_masks(
     image_array: np.array,
     seed_pixels: List[Tuple[int, int]],
     mask_array: np.array,
-    exclusion_mask: List[Tuple],
+    exclusion_mask: np.array,
     contour_expansion=False,
 ) -> np.array:
     """
@@ -411,7 +411,8 @@ def expand_masks(
         image_array (np.array): array that represents an image (float values)
         seed_pixels (List[Tuple[int, int]]): [(x, y), ...]
         mask_array (np.array): MRCNN output; shape: (y, x, mask_index)
-        excluded_pixels (List[Tuple]): [(x, y), ...]
+        exclusion_mask (np.array]: indicates whether or not a pixel is excluded from
+            expansion
         contour_expansion (bool, optional): Indicates whether or not to expand
                                             from contours. Defaults to False.
 
@@ -436,7 +437,7 @@ def expand_masks(
 
 def expansion_coordination(mask_array: np.array,
                            image_array: np.array,
-                           exclusion_mask: List[Tuple]) -> np.array:
+                           exclusion_mask: np.array) -> np.array:
     """
     This function takes a single mask and an image (np.array) and coordinates
     the mask expansion. It returns the expanded mask. The purpose of this function is

--- a/tests/test_mask_expansion.py
+++ b/tests/test_mask_expansion.py
@@ -135,5 +135,29 @@ def test_expansion_coordination():
     assert expected_result.all() == actual_result.all()
 
 
+def test_detect_horizontal_and_vertical_lines():
+    test_image = np.array([[False, False, False, False, False, True, False, False, False, False],
+                           [False, True, False, False, False, True, False, False, True, False],
+                           [False, False, False, False, False, True, False, False, False, False],
+                           [False, False, False, False, False, True, False, False, False, False],
+                           [False, False, False, False, False, True, False, False, False, False],
+                           [True, True, True, True, True, True, True, True, True, True],
+                           [False, False, False, False, False, True, False, False, False, False],
+                           [False, False, False, False, False, True, False, False, False, False],
+                           [False, True, False, False, False, True, False, False, True, False],
+                           [False, False, False, False, False, True, False, False, False, False]])
+    expected_result = np.array([[False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [True, True, True, True, True, True, True, True, True, True],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False],
+                                [False, False, False, False, False, True, False, False, False, False]])
+    actual_result = detect_horizontal_and_vertical_lines(~test_image)
+    np.testing.assert_array_equal(expected_result, actual_result)
+
 def test_complete_structure_mask():
     pass

--- a/tests/test_mask_expansion.py
+++ b/tests/test_mask_expansion.py
@@ -119,19 +119,25 @@ def test_get_neighbour_pixels():
 
 
 def test_expand_masks():
-    test_image_array = np.array([(3, 2)])
-    test_seed_pixels = [(2, 4)]
-    test_mask_array = np.array([(9, 5, 9)])
-    expected_result = np.array([(0.0, 0.0, 0.0)])
-    actual_result = expand_masks(test_image_array, test_seed_pixels, test_mask_array)
+    test_image_array = np.array([(0, 0, 0, 255, 0)])
+    test_seed_pixels = [(2, 0)]
+    test_mask_array = np.array([(True, True, True, True, True)])
+    expected_result = np.array([(True, True, True, False, False)])
+    actual_result = expand_masks(test_image_array,
+                                 test_seed_pixels,
+                                 test_mask_array,
+                                 np.zeros(test_image_array.shape))
     assert expected_result.all() == actual_result.all()
 
 
 def test_expansion_coordination():
+    # TODO: Go through tests and fix nonsense like this
     test_mask_array = np.array([(9, 5, 9)])
     test_image_array = np.array([(3, 2)])
     expected_result = np.array([(9, 5, 9)])
-    actual_result = expansion_coordination(test_mask_array, test_image_array)
+    actual_result = expansion_coordination(test_mask_array,
+                                           test_image_array,
+                                           np.zeros(test_image_array.shape))
     assert expected_result.all() == actual_result.all()
 
 


### PR DESCRIPTION
In order to make the mask expansion a bit more "intelligent" and to avoid that it includes complete tables, I have implemented a very straightforward algorithm:
1) Detect vertical and horizontal lines, that have a length of >= 20% of the image height/width in the dilated image and create a binary mask ("exclusion mask") to label the pixels that belong to these lines.
2) During the mask expansion: Whenever a pixel is in question to be treated as a new seed pixel: Check if it is labelled in the exclusion mask.
     2a) If labelled in the exclusion mask, do not consider it a new seed pixel.
    2b) If not labelled in the exclusion mask: Proceed as usual (add it to the seed pixel list)

This is simple, fast and effective to avoid whole tables being included in the masks because they touch a chemical structure depiction in the dilated image. 
