### PR TITLE
Adaptive exclusion mask line length definition

### DIFF
--- a/.github/workflows/check_errors_and_test.yml
+++ b/.github/workflows/check_errors_and_test.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Error checking and testing
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install basic dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Test with tox
+        run: |
+          pip install -e .
+          pip install tox
+          tox

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,7 +19,7 @@ authors:
 
   
 title: "DECIMER-Image-Segmentation"
-version: 1.1.1
+version: 1.1.4
 doi: 10.5281/zenodo.7299334
 date-released: 2021-05-03
 url: "https://github.com/OBrink/DECIMER-Image-Segmentation"

--- a/decimer_segmentation/__init__.py
+++ b/decimer_segmentation/__init__.py
@@ -10,7 +10,7 @@ For comments, bug reports or feature requests,
 please raise a issue on our Github repository.
 """
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 __all__ = [
     "decimer_segmentation",

--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -368,7 +368,7 @@ def get_neighbour_pixels(
 
 def detect_horizontal_and_vertical_lines(
     image: np.ndarray,
-    average_depiction_size: Tuple[int, int]
+    max_depiction_size: Tuple[int, int]
 ) -> np.ndarray:
     """
     This function takes an image and returns a binary mask that labels the pixels that
@@ -378,6 +378,7 @@ def detect_horizontal_and_vertical_lines(
     Args:
         image (np.ndarray): binarised image (np.array; type bool) as it is returned by
             binary_erosion() in complete_structure_mask()
+        max_depiction_size (Tuple[int, int]): height, width; used as thresholds
 
     Returns:
         np.ndarray: Exclusion mask that contains indices of pixels that are part of
@@ -385,8 +386,8 @@ def detect_horizontal_and_vertical_lines(
     """
     binarised_im = ~image * 255
     binarised_im = binarised_im.astype("uint8")
-    
-    structure_height, structure_width = average_depiction_size
+
+    structure_height, structure_width = max_depiction_size
 
     horizontal_kernel = cv2.getStructuringElement(
         cv2.MORPH_RECT, (structure_width, 1)
@@ -477,23 +478,23 @@ def expansion_coordination(
 def complete_structure_mask(
     image_array: np.array,
     mask_array: np.array,
-    average_depiction_size: Tuple[int, int],
+    max_depiction_size: Tuple[int, int],
     debug=False
 ) -> np.array:
     """
     This funtion takes an image (np.array) and an array containing the masks (shape:
     x,y,n where n is the amount of masks and x and y are the pixel coordinates).
-    Additionally, it takes the average depiction size of the structures in the image
+    Additionally, it takes the maximal depiction size of the structures in the image
     which is used to define the kernel size for the vertical and horizontal line
     detection for the exclusion masks. The exclusion mask is used to exclude pixels
-    from the mask expansion to avoid including whole tables. 
+    from the mask expansion to avoid including whole tables.
     It detects objects on the contours of the mask and expands it until it frames the
     complete object in the image. It returns the expanded mask array
 
     Args:
         image_array (np.array): input image
         mask_array (np.array): shape: y, x, n where n is the amount of masks
-        average_depiction_size (Tuple[int, int]): height, width
+        max_depiction_size (Tuple[int, int]): height, width
         debug (bool, optional): More verbose if True. Defaults to False.
 
     Returns:
@@ -519,7 +520,7 @@ def complete_structure_mask(
             [mask_array[:, :, index] for index in range(mask_array.shape[2])]
         )
         exclusion_mask = detect_horizontal_and_vertical_lines(blurred_image_array,
-                                                              average_depiction_size)
+                                                              max_depiction_size)
         # Run expansion the expansion
         image_repeat = itertools.repeat(blurred_image_array, mask_array.shape[2])
         exclusion_mask_repeat = itertools.repeat(exclusion_mask, mask_array.shape[2])

--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -366,7 +366,10 @@ def get_neighbour_pixels(
     return neighbour_pixels
 
 
-def detect_horizontal_and_vertical_lines(image: np.ndarray) -> np.ndarray:
+def detect_horizontal_and_vertical_lines(
+    image: np.ndarray,
+    average_depiction_size: Tuple[int, int]
+) -> np.ndarray:
     """
     This function takes an image and returns a binary mask that labels the pixels that
     are part of long horizontal or vertical lines. [Definition of long: 1/5 of the
@@ -382,19 +385,19 @@ def detect_horizontal_and_vertical_lines(image: np.ndarray) -> np.ndarray:
     """
     binarised_im = ~image * 255
     binarised_im = binarised_im.astype("uint8")
+    
+    structure_height, structure_width = average_depiction_size
 
-    horizontal_kernel_size = int(binarised_im.shape[1] / 7)
     horizontal_kernel = cv2.getStructuringElement(
-        cv2.MORPH_RECT, (horizontal_kernel_size, 1)
+        cv2.MORPH_RECT, (structure_width, 1)
     )
     horizontal_mask = cv2.morphologyEx(
         binarised_im, cv2.MORPH_OPEN, horizontal_kernel, iterations=2
     )
     horizontal_mask = horizontal_mask == 255
 
-    vertical_kernel_size = int(binarised_im.shape[0] / 7)
     vertical_kernel = cv2.getStructuringElement(
-        cv2.MORPH_RECT, (1, vertical_kernel_size)
+        cv2.MORPH_RECT, (1, structure_height)
     )
     vertical_mask = cv2.morphologyEx(
         binarised_im, cv2.MORPH_OPEN, vertical_kernel, iterations=2
@@ -472,13 +475,30 @@ def expansion_coordination(
 
 
 def complete_structure_mask(
-    image_array: np.array, mask_array: np.array, debug=False
+    image_array: np.array,
+    mask_array: np.array,
+    average_depiction_size: Tuple[int, int],
+    debug=False
 ) -> np.array:
     """
-    This funtion takes an image (array) and an array containing the masks (shape:
+    This funtion takes an image (np.array) and an array containing the masks (shape:
     x,y,n where n is the amount of masks and x and y are the pixel coordinates).
+    Additionally, it takes the average depiction size of the structures in the image
+    which is used to define the kernel size for the vertical and horizontal line
+    detection for the exclusion masks. The exclusion mask is used to exclude pixels
+    from the mask expansion to avoid including whole tables. 
     It detects objects on the contours of the mask and expands it until it frames the
-    complete object in the image. It returns the expanded mask array"""
+    complete object in the image. It returns the expanded mask array
+
+    Args:
+        image_array (np.array): input image
+        mask_array (np.array): shape: y, x, n where n is the amount of masks
+        average_depiction_size (Tuple[int, int]): height, width
+        debug (bool, optional): More verbose if True. Defaults to False.
+
+    Returns:
+        np.array: expanded mask array
+    """
 
     if mask_array.size != 0:
         # Binarization of input image
@@ -498,7 +518,8 @@ def complete_structure_mask(
         split_mask_arrays = np.array(
             [mask_array[:, :, index] for index in range(mask_array.shape[2])]
         )
-        exclusion_mask = detect_horizontal_and_vertical_lines(blurred_image_array)
+        exclusion_mask = detect_horizontal_and_vertical_lines(blurred_image_array,
+                                                              average_depiction_size)
         # Run expansion the expansion
         image_repeat = itertools.repeat(blurred_image_array, mask_array.shape[2])
         exclusion_mask_repeat = itertools.repeat(exclusion_mask, mask_array.shape[2])

--- a/decimer_segmentation/complete_structure.py
+++ b/decimer_segmentation/complete_structure.py
@@ -383,7 +383,7 @@ def detect_horizontal_and_vertical_lines(image: np.ndarray) -> np.ndarray:
     binarised_im = ~image * 255
     binarised_im = binarised_im.astype("uint8")
 
-    horizontal_kernel_size = int(binarised_im.shape[1] / 5)
+    horizontal_kernel_size = int(binarised_im.shape[1] / 7)
     horizontal_kernel = cv2.getStructuringElement(
         cv2.MORPH_RECT, (horizontal_kernel_size, 1)
     )
@@ -392,7 +392,7 @@ def detect_horizontal_and_vertical_lines(image: np.ndarray) -> np.ndarray:
     )
     horizontal_mask = horizontal_mask == 255
 
-    vertical_kernel_size = int(binarised_im.shape[0] / 5)
+    vertical_kernel_size = int(binarised_im.shape[0] / 7)
     vertical_kernel = cv2.getStructuringElement(
         cv2.MORPH_RECT, (1, vertical_kernel_size)
     )

--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -128,7 +128,8 @@ def sort_segments_bboxes(
     Args:
         segments - image segments to be sorted
         bboxes - bounding boxes containing edge coordinates of the image segments
-        same_row_pixel_threshold - how many pixels apart can two pixels be to be considered "on the same row"
+        same_row_pixel_threshold - how many pixels apart can two pixels be to be
+            considered "on the same row"
 
     Returns:
         segments and bboxes in reading order
@@ -280,8 +281,7 @@ def apply_mask(image: np.array, mask: np.array) -> np.array:
     background = dst[y : y + h, x : x + w]
     trans_mask = background[:, :, 3] == 0
     background[trans_mask] = [255, 255, 255, 255]
-    segmented_image = cv2.cvtColor(background, cv2.COLOR_BGRA2BGR)
-    return segmented_image, (y, x, y + h, x + w)
+    return background, (y, x, y + h, x + w)
 
 
 def get_masked_image(image: np.array, mask: np.array) -> np.array:

--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -98,7 +98,6 @@ def segment_chemical_structures(
     if not expand:
         masks, bboxes, _ = get_mrcnn_results(image)
     else:
-        average_height, average_width = determine_average_depiction_size(bboxes)
         masks = get_expanded_masks(image)
 
     segments, bboxes = apply_masks(image, masks)
@@ -227,9 +226,12 @@ def get_expanded_masks(image: np.array) -> np.array:
         np.array: expanded masks (shape: (h, w, num_masks))
     """
     # Structure detection with MRCNN
-    masks, _, _ = get_mrcnn_results(image)
+    masks, bboxes, _ = get_mrcnn_results(image)
+    size = determine_average_depiction_size(bboxes)
     # Mask expansion
-    expanded_masks = complete_structure_mask(image_array=image, mask_array=masks)
+    expanded_masks = complete_structure_mask(image_array=image,
+                                             mask_array=masks,
+                                             average_depiction_size=size,)
     return expanded_masks
 
 

--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -121,7 +121,7 @@ def determine_depiction_size_with_buffer(
     bboxes: List[Tuple[int, int, int, int]]
 ) -> Tuple[int, int]:
     """
-    This function takes a list of bounding boxes and returns 1.2 * the maximal
+    This function takes a list of bounding boxes and returns 1.1 * the maximal
     depiction size (height, width) of the depicted chemical structures.
 
     Args:
@@ -138,8 +138,8 @@ def determine_depiction_size_with_buffer(
         width = bbox[3] - bbox[1]
         heights.append(height)
         widths.append(width)
-    height = int(1.2 * np.max(heights))
-    width = int(1.2 * np.max(widths))
+    height = int(1.1 * np.max(heights))
+    width = int(1.1 * np.max(widths))
     return height, width
 
 

--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -117,11 +117,11 @@ def segment_chemical_structures(
     return segments
 
 
-def determine_average_depiction_size(
+def determine_depiction_size_with_buffer(
     bboxes: List[Tuple[int, int, int, int]]
 ) -> Tuple[int, int]:
     """
-    This function takes a list of bounding boxes and returns the average
+    This function takes a list of bounding boxes and returns 1.2 * the maximal
     depiction size (height, width) of the depicted chemical structures.
 
     Args:
@@ -138,9 +138,9 @@ def determine_average_depiction_size(
         width = bbox[3] - bbox[1]
         heights.append(height)
         widths.append(width)
-    average_height = int(np.mean(heights))
-    average_width = int(np.mean(widths))
-    return int(average_height), int(average_width)
+    height = int(1.2 * np.max(heights))
+    width = int(1.2 * np.max(widths))
+    return height, width
 
 
 def sort_segments_bboxes(
@@ -227,11 +227,11 @@ def get_expanded_masks(image: np.array) -> np.array:
     """
     # Structure detection with MRCNN
     masks, bboxes, _ = get_mrcnn_results(image)
-    size = determine_average_depiction_size(bboxes)
+    size = determine_depiction_size_with_buffer(bboxes)
     # Mask expansion
     expanded_masks = complete_structure_mask(image_array=image,
                                              mask_array=masks,
-                                             average_depiction_size=size,)
+                                             max_depiction_size=size,)
     return expanded_masks
 
 

--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -96,8 +96,9 @@ def segment_chemical_structures(
         a certain tolerance for grouping into "lines"(shape: (h, w, num_masks))
     """
     if not expand:
-        masks, _, _ = get_mrcnn_results(image)
+        masks, bboxes, _ = get_mrcnn_results(image)
     else:
+        average_height, average_width = determine_average_depiction_size(bboxes)
         masks = get_expanded_masks(image)
 
     segments, bboxes = apply_masks(image, masks)
@@ -115,6 +116,32 @@ def segment_chemical_structures(
         segments, bboxes = sort_segments_bboxes(segments, bboxes)
 
     return segments
+
+
+def determine_average_depiction_size(
+    bboxes: List[Tuple[int, int, int, int]]
+) -> Tuple[int, int]:
+    """
+    This function takes a list of bounding boxes and returns the average
+    depiction size (height, width) of the depicted chemical structures.
+
+    Args:
+        bboxes (List[Tuple[int, int, int, int]]): bounding boxes of the structure
+            depictions (y0, x0, y1, x1)
+
+    Returns:
+        Tuple: average depiction size (height, width)
+    """
+    heights = []
+    widths = []
+    for bbox in bboxes:
+        height = bbox[2] - bbox[0]
+        width = bbox[3] - bbox[1]
+        heights.append(height)
+        widths.append(width)
+    average_height = int(np.mean(heights))
+    average_width = int(np.mean(widths))
+    return int(average_height), int(average_width)
 
 
 def sort_segments_bboxes(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="decimer_segmentation",
-    version="1.1.3",
+    version="1.1.4",
     author="Kohulan Rajan",
     author_email="kohulan.rajan@uni-jena.de",
     maintainer="Kohulan Rajan",

--- a/tests/test_decimer_segmentation.py
+++ b/tests/test_decimer_segmentation.py
@@ -1,8 +1,9 @@
-import numpy as np
-from decimer_segmentation.decimer_segmentation import *
+from decimer_segmentation.decimer_segmentation import (
+    determine_depiction_size_with_buffer
+)
 
 def test_determine_depiction_size_with_buffer():
-    # Determine the average depiction size of the structures in a given list of structures
+    # Determine 1.1 * max depiction size of the structures in a given list of bboxes
     bboxes = [
         [0, 0, 6, 6],
         [0, 0, 8, 8],

--- a/tests/test_decimer_segmentation.py
+++ b/tests/test_decimer_segmentation.py
@@ -1,13 +1,13 @@
 import numpy as np
 from decimer_segmentation.decimer_segmentation import *
 
-def test_determine_average_depiction_size():
+def test_determine_depiction_size_with_buffer():
     # Determine the average depiction size of the structures in a given list of structures
     bboxes = [
         [0, 0, 6, 6],
         [0, 0, 8, 8],
         [0, 0, 10, 10],
     ]
-    expected_result = (8, 8)
-    actual_result = determine_average_depiction_size(bboxes)
+    expected_result = (12, 12)
+    actual_result = determine_depiction_size_with_buffer(bboxes)
     assert expected_result == actual_result

--- a/tests/test_decimer_segmentation.py
+++ b/tests/test_decimer_segmentation.py
@@ -1,0 +1,13 @@
+import numpy as np
+from decimer_segmentation.decimer_segmentation import *
+
+def test_determine_average_depiction_size():
+    # Determine the average depiction size of the structures in a given list of structures
+    bboxes = [
+        [0, 0, 6, 6],
+        [0, 0, 8, 8],
+        [0, 0, 10, 10],
+    ]
+    expected_result = (8, 8)
+    actual_result = determine_average_depiction_size(bboxes)
+    assert expected_result == actual_result

--- a/tests/test_decimer_segmentation.py
+++ b/tests/test_decimer_segmentation.py
@@ -8,6 +8,6 @@ def test_determine_depiction_size_with_buffer():
         [0, 0, 8, 8],
         [0, 0, 10, 10],
     ]
-    expected_result = (12, 12)
+    expected_result = (11, 11)
     actual_result = determine_depiction_size_with_buffer(bboxes)
     assert expected_result == actual_result

--- a/tests/test_mask_expansion.py
+++ b/tests/test_mask_expansion.py
@@ -1,5 +1,19 @@
 import numpy as np
-from decimer_segmentation.complete_structure import *
+from decimer_segmentation.complete_structure import (
+    get_bounding_box_center,
+    get_edge_line,
+    get_euklidian_distance,
+    set_x_range,
+    get_next_pixel_to_check,
+    adapt_x_values,
+    get_contour_seeds,
+    get_mask_center,
+    get_seeds,
+    get_neighbour_pixels,
+    expand_masks,
+    expansion_coordination,
+    detect_horizontal_and_vertical_lines,
+)
 
 
 def test_get_bounding_box_center():
@@ -31,7 +45,8 @@ def test_get_euklidian_distance():
 
 
 def test_set_x_range():
-    # For the contour-based expansion, non-white pixels on the contours of the original polygon bounding box are detected
+    # For the contour-based expansion, non-white pixels on the contours of the original
+    # polygon bounding box are detected
     test_distance = 3
     test_eukl_distance = 4
     test_image_array = np.array([[1, 5]])
@@ -55,7 +70,8 @@ def test_get_next_pixel_to_check():
 
 
 def test_adapt_x_values():
-    # Returns a bounding box where the nodes are altered depending on their relative position to bounding box centre
+    # Returns a bounding box where the nodes are altered depending on their relative
+    # position to bounding box centre
     test_bounding_box = np.array([[1, 5], [2, 4]])
     test_node_index = 1
     test_image_shape = [2, 4, 6]

--- a/tests/test_mask_expansion.py
+++ b/tests/test_mask_expansion.py
@@ -153,7 +153,7 @@ def test_detect_horizontal_and_vertical_lines():
         [[False] * 20] * 20
     )
     expected_result[9] = np.array([True] * 20)
-    actual_result = detect_horizontal_and_vertical_lines(~test_image)
+    actual_result = detect_horizontal_and_vertical_lines(~test_image, (2, 2))
     np.testing.assert_array_equal(expected_result, actual_result)
 
 

--- a/tests/test_mask_expansion.py
+++ b/tests/test_mask_expansion.py
@@ -145,33 +145,14 @@ def test_expansion_coordination():
 
 def test_detect_horizontal_and_vertical_lines():
     test_image = np.array(
-        [
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, True, False, False, False, True, False, False, True, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [True, True, True, True, True, True, True, True, True, True],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, True, False, False, False, True, False, False, True, False],
-            [False, False, False, False, False, True, False, False, False, False],
-        ]
+        [[False] * 20] * 20
     )
+    test_image[9] = np.array([True] * 20)
+    test_image[2][3] = True
     expected_result = np.array(
-        [
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [True, True, True, True, True, True, True, True, True, True],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, True, False, False, False, False],
-        ]
+        [[False] * 20] * 20
     )
+    expected_result[9] = np.array([True] * 20)
     actual_result = detect_horizontal_and_vertical_lines(~test_image)
     np.testing.assert_array_equal(expected_result, actual_result)
 


### PR DESCRIPTION
- Adaptive size for kernel for line detection:
    - threshold height for vertical lines: 1.1 * max height (based on mrcnn model output mask)
    - threshold width for horizontal lines: 1.1 * max width (based on mrcnn model output mask)

This way, we can make sure that no pixels in a chemical structure end up in the exclusion mask; and choose a kernel that's just a bit bigger than this threshold.