### PR TITLE
fix: GH action for pypi releases

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distributions 📦 to PyPI
+name: Publish Python distributions to PyPI
 
 on:
   release:
@@ -6,8 +6,8 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    name: Build and publish Python distributions to PyPI
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.10
@@ -15,13 +15,10 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install pypa/setuptools
-      run: >-
-        python -m
-        pip install wheel
+      run: python -m pip install wheel
     - name: Build a binary wheel
-      run: >-
-        python setup.py sdist bdist_wheel
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      run: python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@v2.0.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This should hopefully fix it. The GH action did not run after the last release in the repository.