### PR TITLE
fix: expansion crash when no structures have been detected #95

### DIFF
--- a/decimer_segmentation/decimer_segmentation.py
+++ b/decimer_segmentation/decimer_segmentation.py
@@ -227,6 +227,8 @@ def get_expanded_masks(image: np.array) -> np.array:
     """
     # Structure detection with MRCNN
     masks, bboxes, _ = get_mrcnn_results(image)
+    if len(bboxes) == 0:
+        return masks
     size = determine_depiction_size_with_buffer(bboxes)
     # Mask expansion
     expanded_masks = complete_structure_mask(


### PR DESCRIPTION
This fixes a problem that I have introduced with the horizontal/vertical line detection for the exclusion masks.